### PR TITLE
Relax bundler dependency to allow bundler v2.0

### DIFF
--- a/ruby-dnn.gemspec
+++ b/ruby-dnn.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16", "<3.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
Hi @unagiootoro 
Great work!
I find that bundler v2 does not work in your project. Why don't you update a gemspec file?

Style 1
https://github.com/rubocop-hq/rubocop/blob/master/rubocop.gemspec#L45

Style 2
https://github.com/ruby-numo/numo-narray/blob/2d05d8fde74df180ead1e68178f5b5abed7fe386/numo-narray.gemspec#L31-L35