### PR TITLE
Set Yard to development_dependency

### DIFF
--- a/ruby-dnn.gemspec
+++ b/ruby-dnn.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "numo-narray"
   spec.add_dependency "archive-tar-minitar"
-  spec.add_dependency "yard"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.7
@@ -42,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "yard"
 end


### PR DESCRIPTION
I think it's more common to set Yard to development_dependency.
Because ruby-dnn doesn't use Yard as a library, but rather as a tool to generate documentation.
Just a suggestion. I'm sorry if I'm wrong.