### PR TITLE
Fix gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.lock


### PR DESCRIPTION
Add `Gemfile.lock` to `.gitignore`
`Gemfile.lock` is generated when you run `bundle install` command in the ruby-dnn directory.

* You should include Gemfile.lock when you create applications. 
* You should not include the Gemfile.lock when you create libraries(Gem). 

See https://techracho.bpsinc.jp/hachi8833/2014_02_07/15390 (Japanese) for details. 

> gemを作るときには逆にGemfile.lockをリポジトリに含めないのが定石です。